### PR TITLE
use status library functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Requires Status 0.9.4+ and Embark 2.4.0+**
+
 # Installation
 
 ```npm install embark-status --save```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "dependencies": {
     "request": "^2.79.0",
-    "status-dev-cli": "^2.2.1"
+    "status-dev-cli": "iurimatias/status-dev-cli#master"
   }
 }


### PR DESCRIPTION
restructured to uses the status-dev-cli library. the version in package.json should be later changed to the one that is actually released.

Note: I don't have the latest version of status so I couldn't test the switch network functionality yet