### PR TITLE
fix(@embark-status): Fix support for IPFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,39 @@ Add this config in the dApp's `embark.json`:
   }
 ```
 ### Development environment
-To configure for a development environment, the blockchain client and the webserver need to be set up to accept outside connections.
+To configure for a development environment, the blockchain client, webserver, and storage need to be set up to accept outside connections.
 #### Blockchain client
 Set `config/blockchain.js > development > rpcHost` to `0.0.0.0`. This will open up your blockchain client (Geth or Parity) to outside connections.
 #### Webserver
 Set `config/webserver.js > host` to `0.0.0.0`. This will open up your webserver to outside connections.
 > NOTE: When the Status browser opens the dApp, it will open the IP of the machine running Embark along with the port specified in the webserver config, ie `http://192.168.0.15:8000`. This is so that the device can connect to the webserver started by Embark.
+#### Storage
+Our machine will be running our storage node, and we need to access the node from our dApp, so we have to configure IPFS to run on our machine's IP, then tell embark to access the node via the machine IP.
+> NOTE: `embark-status` has only been tested with IPFS. This guide assumes you have [ipfs installed](https://docs.ipfs.io/introduction/install/) and you are using it for your dApp.
+
+Set `config/storage.js > dappConnection` to
+```
+dappConnection: [
+  {
+    provider: "ipfs",
+    host: "your-machine-ip",
+    port: 5001,
+    getUrl: "http://your-machine-ip:8080/ipfs/"
+  }
+]
+```
+Then run the following commands:
+```
+ipfs config --json Addresses.API "\"/ip4/0.0.0.0/tcp/5001\""
+ipfs config --json Addresses.Gateway "\"/ip4/0.0.0.0/tcp/5001\""
+```
+> NOTE: These commands change your local IPFS config so that IPFS can be used on any IP. In this case, we want the IPFS API and gateway to the be accessible from our machine's IP.
+
+If you'd like to revert to the default settings, run the following two commands:
+```
+ipfs config --json Addresses.API "\"/ip4/127.0.0.1/tcp/5001\""
+ipfs config --json Addresses.Gateway "\"/ip4/127.0.0.1/tcp/5001\""
+```
 
 ### Hosted dApp
 If your dApp is hosted (ie on decentralised storage like IPFS or Swarm), the plugin option `dappUrl` can be specified to override the dApp URL that is opened in the Status dApp browser after `embark-status` is connected to the Status app.

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ dappConnection: [
   }
 ]
 ```
-Then run the following commands:
+Then run the following commands, of course replacing `your-machine-ip` with your machine's IP:
 ```
-ipfs config --json Addresses.API "\"/ip4/0.0.0.0/tcp/5001\""
-ipfs config --json Addresses.Gateway "\"/ip4/0.0.0.0/tcp/5001\""
+ipfs config --json Addresses.API "\"/ip4/your-machine-ip/tcp/5001\""
+ipfs config --json Addresses.Gateway "\"/ip4/your-machine-ip/tcp/5001\""
 ```
-> NOTE: These commands change your local IPFS config so that IPFS can be used on any IP. In this case, we want the IPFS API and gateway to the be accessible from our machine's IP.
+> NOTE: In this case, we want the IPFS API and gateway to the be accessible from our machine's IP.
 
 If you'd like to revert to the default settings, run the following two commands:
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,8 @@ const NOT_RUNNING_RESPONSES = ['ECONNREFUSED', 'ETIMEDOUT'];
 // Private backing variables
 let _networkSettings = null;
 
+const MACHINE_IP = Ip.address();
+
 /**
  * Plugin that connects an Embark dApp to the Status app, and allows the dApp
  * to be run in the Status browser.
@@ -52,6 +54,7 @@ class EmbarkStatusPlugin {
     this.events.on('config:load:webserver', webServerConfig => {
       this.webServerConfig = webServerConfig;
       _networkSettings = null; // reset backing var to recompute hash
+      this.events.request('config:cors:add', buildUrl(DEVICE_PROTOCOL, MACHINE_IP, this.webServerConfig.port, 'http'));
     });
 
     // gets hydrated blockchain config from embark
@@ -61,7 +64,7 @@ class EmbarkStatusPlugin {
     });
 
     // adds cors to blockchain and storage clients
-    this.events.request('config:cors:add', `${DEVICE_PROTOCOL}://${this.deviceIp}`);
+    this.events.request('config:cors:add', buildUrl(DEVICE_PROTOCOL, this.deviceIp, false, 'http'));
 
     // register service check
     //this._registerServiceCheck();
@@ -91,7 +94,7 @@ class EmbarkStatusPlugin {
       const nodePort = this.blockchainConfig.proxy ? this.blockchainConfig.rpcPort + 10 : this.blockchainConfig.rpcPort;
       let blockchainHost = this.blockchainConfig.rpcHost;
       if (LOCAL_HOSTS.some(host => host === blockchainHost)) {
-        blockchainHost = Ip.address();
+        blockchainHost = MACHINE_IP;
       }
       const nodeUrl = buildUrl('http', blockchainHost, nodePort);
       const networkName = `${NETWORK_NAME} (${this.pluginConfig.name})`;
@@ -162,7 +165,7 @@ class EmbarkStatusPlugin {
   openDapp(cb) {
     let dappHost = this.webServerConfig.host;
     if (LOCAL_HOSTS.some(host => host === dappHost)) {
-      dappHost = Ip.address();
+      dappHost = MACHINE_IP;
     }
     const dappUrl = this.pluginConfig.dappUrl || buildUrl('http', dappHost, this.webServerConfig.port) + '/';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,7 @@
  *  The URL host, required.
  * @param {string} port
  *  The URL port, default to empty string.
- * @param {string} [type]
+ * @param {any} [type]
  *  Type of connection - used when protocol is false or not specified. Valid options
  *  are 'ws' and 'http'.
  * @returns {string} the constructued URL, with defaults


### PR DESCRIPTION
Previously, `embark-status` was meant to support IPFS but was experiencing CORS issues that would not allow successful API/gateway requests when being served to non-localhost URLs.

This PR includes a change for using including the port in the URL added to IPFS CORS, and moves the CORS update call to after the webserver is loaded.

For this funcationality to work correctly, https://github.com/embark-framework/embark/pull/1139 is needed.